### PR TITLE
Upload all files from manifest to S3

### DIFF
--- a/spec/manifest_uploader_spec.rb
+++ b/spec/manifest_uploader_spec.rb
@@ -4,12 +4,17 @@ require 'everlane/asset_upload'
 describe Everlane::AssetUpload::ManifestUploader do
   let(:manifest) do
     {
-      'admin-9c00faff.css' => '/assets/admin-9c00faff.css',
-      'admin-9c00faff.css.map' => '/assets/admin-9c00faff.css.map',
-      'entrypoints' => {
-        'admin' => {
-          'css' => [ '/assets/admin-9c00faff.css' ],
-          'css.map' => [ '/assets/admin-9c00faff.css.map' ],
+      "admin.css": "/assets/css/admin-04149f31.chunk.css",
+      "admin.js": "/assets/js/admin-4350ce6e88a92e869e8d.chunk.js",
+      "entrypoints": {
+        "admin": {
+          "js": [
+            "/assets/js/sonic-851fd1bf641b3d41397b.js",
+            "/assets/js/admin-4350ce6e88a92e869e8d.chunk.js"
+          ],
+          "css": [
+            "/assets/css/admin-04149f31.chunk.css"
+          ],
         },
       },
     }
@@ -29,19 +34,21 @@ describe Everlane::AssetUpload::ManifestUploader do
 
     it 'creates a file-upload for each manifest item, ignoring "entrypoints"' do
       files = subject.files
-      expect(files.length).to eq(2)
+      expect(files.length).to eq(3)
     end
 
     it 'expands the full local path' do
       files = subject.files
-      expect(files[0].local_path).to eq('/path/to/app/public/assets/admin-9c00faff.css')
-      expect(files[1].local_path).to eq('/path/to/app/public/assets/admin-9c00faff.css.map')
+      expect(files[0].local_path).to eq('/path/to/app/public/assets/css/admin-04149f31.chunk.css')
+      expect(files[1].local_path).to eq('/path/to/app/public/assets/js/admin-4350ce6e88a92e869e8d.chunk.js')
+      expect(files[2].local_path).to eq('/path/to/app/public/assets/js/sonic-851fd1bf641b3d41397b.js')
     end
 
     it 'passes the webpack public path through with leading / removed' do
       files = subject.files
-      expect(files[0].remote_path).to eq('assets/admin-9c00faff.css')
-      expect(files[1].remote_path).to eq('assets/admin-9c00faff.css.map')
+      expect(files[0].remote_path).to eq('assets/css/admin-04149f31.chunk.css')
+      expect(files[1].remote_path).to eq('assets/js/admin-4350ce6e88a92e869e8d.chunk.js')
+      expect(files[2].remote_path).to eq('assets/js/sonic-851fd1bf641b3d41397b.js')
     end
   end
 


### PR DESCRIPTION
In preparation for code splitting, we want to upload all of our chunks to S3. Previously, we discarded the object in `entrypoints` because the dependencies in there were redundant. Now that node modules are separate from our main assets, we need to upload those dependencies to S3 as well.